### PR TITLE
Added Serilog and AppInsights

### DIFF
--- a/template/.template.config/template.json
+++ b/template/.template.config/template.json
@@ -51,7 +51,18 @@
             "type": "computed",
             "value": "(!disable-health-check)",
             "replaces": "enableHealthCheckValue"
-        }
+        },
+        "disable-serilogging":{
+            "type": "parameter",
+            "datatype": "bool",
+            "description": "Disable Serilogging and AppInsights support.",
+            "defaultValue": "false"
+        },
+        "enableSerilog": {
+            "type": "computed",
+            "value": "(!disable-serilogging)",
+            "replaces": "enableSerilogValue"
+        }        
     },
     "postActions": [
         {

--- a/template/AksApi.csproj
+++ b/template/AksApi.csproj
@@ -5,6 +5,13 @@
   </PropertyGroup>
   <!--#if (enableOpenApi) -->
   <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.15.0" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
+    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="3.1.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
   </ItemGroup>
   <!--#endif -->

--- a/template/Controllers/v1/SampleController.cs
+++ b/template/Controllers/v1/SampleController.cs
@@ -18,6 +18,7 @@ namespace AksApi.Controllers.v1
         [HttpGet]
         public string Get()
         {
+            logger.LogInformation("Hello World");
             return "Hello, World!";
         }
     }

--- a/template/Options/ApplicationInsightsOptions.cs
+++ b/template/Options/ApplicationInsightsOptions.cs
@@ -1,0 +1,9 @@
+﻿namespace AksApi.Options
+{
+    public class ApplicationInsightsOptions
+    {
+        public string InstrumentationKey { get; set; }
+        public string MinimumLogLevel { get; set; }
+        public bool EnableAdaptiveSampling { get; set; }
+    }
+}

--- a/template/Options/EnvironmentOptions.cs
+++ b/template/Options/EnvironmentOptions.cs
@@ -1,0 +1,9 @@
+﻿namespace AksApi.Options
+{
+    public class EnvironmentOptions
+    {
+        public string EnvironmentName { get; set; }
+        public string Region { get; set; }
+        public string ApplicationName { get; set; }
+    }
+}

--- a/template/Program.cs
+++ b/template/Program.cs
@@ -1,5 +1,15 @@
+using AksApi.Options;
+using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
+#if (enableSerolog)
+using Serilog;
+using Serilog.Events;
+using Serilog.Sinks.ApplicationInsights.Sinks.ApplicationInsights.TelemetryConverters;
+using System;
+using System.IO;
+#endif
 
 namespace AksApi
 {
@@ -7,14 +17,62 @@ namespace AksApi
     {
         public static void Main(string[] args)
         {
-            CreateHostBuilder(args).Build().Run();
+#if (enableSerolog)
+            var config = new ConfigurationBuilder()
+                .SetBasePath(Directory.GetCurrentDirectory())
+                .AddJsonFile("appsettings.json", false, true)
+                .AddEnvironmentVariables()
+                .Build();
+#endif
+
+            var host = CreateHostBuilder(args).Build();
+#if (enableSerolog)
+            ConfigureLogger(config, host.Services);
+#endif
+            host.Run();
+
         }
 
-        public static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args)
-                .ConfigureWebHostDefaults(webBuilder =>
-                {
-                    webBuilder.UseStartup<Startup>();
-                });
+        public static IWebHostBuilder CreateHostBuilder(string[] args) =>
+            WebHost.CreateDefaultBuilder(args)
+#if (enableSerolog)
+            .UseStartup<Startup>()
+            .UseSerilog();
+#else
+            .UseStartup<Startup>();
+#endif
+
+#if (enableSerolog)
+        public static void ConfigureLogger(IConfigurationRoot configurationRoot, IServiceProvider services)
+        {
+            var applicationInsightsOptions = new ApplicationInsightsOptions();
+            configurationRoot.GetSection("ApplicationInsights").Bind(applicationInsightsOptions);
+            var environmentOptions = new EnvironmentOptions();
+            configurationRoot.GetSection("environmentoptions").Bind(environmentOptions);
+
+            var config = new LoggerConfiguration();
+
+            config.MinimumLevel.Is(LogEventLevelFromConfig(applicationInsightsOptions.MinimumLogLevel));
+            config.MinimumLevel.Override("Microsoft", LogEventLevel.Error);
+            config.MinimumLevel.Override("System", LogEventLevel.Error);
+
+            config.WriteTo.Console(
+                outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {EventCode}{Message:lj}{NewLine}{SavedItemMessage}{Exception}{NewLine}", standardErrorFromLevel: LogEventLevel.Verbose);
+
+            config.WriteTo.ApplicationInsights(applicationInsightsOptions.InstrumentationKey, new EventTelemetryConverter(), LogEventLevelFromConfig(applicationInsightsOptions.MinimumLogLevel));
+
+            config.Enrich.WithProperty("ApplicationName", environmentOptions.ApplicationName);
+            config.Enrich.WithProperty("Region", environmentOptions.Region);
+            config.Enrich.WithProperty("Environment", environmentOptions.EnvironmentName);
+            config.Enrich.FromLogContext();
+
+            Log.Logger = config.CreateLogger();
+        }
+
+        private static LogEventLevel LogEventLevelFromConfig(string logEventLevel)
+        {
+            return !Enum.TryParse(logEventLevel, true, out LogEventLevel level) ? LogEventLevel.Information : level;
+        }
+#endif
     }
 }

--- a/template/Properties/launchSettings.json
+++ b/template/Properties/launchSettings.json
@@ -1,0 +1,35 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:50155/",
+      "sslPort": 44332
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "AksApi": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:5001;http://localhost:5000"
+    },
+    "AksApiConsole": {
+      "commandName": "Project",
+      "launchBrowser": false,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:5001;http://localhost:5000"
+    }
+  }
+}

--- a/template/Startup.cs
+++ b/template/Startup.cs
@@ -1,3 +1,5 @@
+using AksApi.Options;
+using Microsoft.ApplicationInsights.AspNetCore.Extensions;
 using Microsoft.AspNetCore.Builder;
 #if (enableHealthCheck)
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
@@ -30,6 +32,18 @@ namespace AksApi
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+#if (enableSerolog)
+         var applicationInsightsOptions = new ApplicationInsightsOptions();
+         Configuration.GetSection("ApplicationInsights").Bind(applicationInsightsOptions);
+         var applicationInsightsServiceOptions = new ApplicationInsightsServiceOptions
+         {
+            EnableAdaptiveSampling = applicationInsightsOptions.EnableAdaptiveSampling,
+            InstrumentationKey     = applicationInsightsOptions.InstrumentationKey
+         };
+
+         services.AddApplicationInsightsTelemetry(applicationInsightsServiceOptions);
+#endif
+
             services.AddControllers();
 #if (enableOpenApi)
 

--- a/template/appsettings.json
+++ b/template/appsettings.json
@@ -1,0 +1,22 @@
+{
+	"environmentoptions": {
+		"EnvironmentName": "local-machine",
+		"Region": "local-region",
+		"ApplicationName": "AksApi"
+	},
+	"ApplicationInsights": {
+		"InstrumentationKey": "<<INSTRUMENTATION KEY>>",
+		"MinimumLogLevel": "Verbose",
+		"EnableAdaptiveSampling": "true"
+	},
+	"Logging": {
+		"IncludeScopes": false,
+		"Console": {
+			"LogLevel": {
+				"Default": "Trace",
+				"System": "Error",
+				"Microsoft": "Error"
+			}
+		}
+	}
+}


### PR DESCRIPTION
This may be too much at once. But this adds Serilog to the Api, allowing Serilog to log to both the Console and Application Insights. It also enables event capturing, i.e. requests, to Application Insights.