### PR TITLE
Move readiness and liveness probe blocks to correct indentation.

### DIFF
--- a/template/chart/templates/deployment.yaml
+++ b/template/chart/templates/deployment.yaml
@@ -26,15 +26,15 @@ spec:
               value: {{ .Values.apphost }}
             - name: appenvironment
               value: {{ .Values.environment}}
-              //#if (enableHealthCheckValue)
-              readinessProbe:
-                httpGet:
-                  path: /health/ready
-                  port: {{ .Values.container.port }}
-                initialDelaySeconds: {{ .Values.container.probeDelay }}
-              livenessProbe:
-                httpGet:
-                  path: /health/live
-                  port: {{ .Values.container.port }}
-                initialDelaySeconds: {{ .Values.container.probeDelay }}
-            //#endif
+          //#if (enableHealthCheckValue)
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: {{ .Values.container.port }}
+            initialDelaySeconds: {{ .Values.container.probeDelay }}
+          livenessProbe:
+            httpGet:
+              path: /health/live
+              port: {{ .Values.container.port }}
+            initialDelaySeconds: {{ .Values.container.probeDelay }}
+          //#endif


### PR DESCRIPTION
After creating a new project from the template and attempting to deploy via helm:
`helm upgrade --install sample .\chart\`
```bash
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: 
  ValidationError(Deployment.spec.template.spec.containers[0].env[1]):
    unknown field "livenessProbe" in io.k8s.api.core.v1.EnvVar,
  ValidationError(Deployment.spec.template.spec.containers[0].env[1]):
    unknown field "readinessProbe" in io.k8s.api.core.v1.EnvVar]
```

Fixed by adjusting the indentation of readiness and liveness probe blocks in the `deployment.yaml` template.